### PR TITLE
Enlarge DoorLock buttons and rename decode-keyboard CSS to keyboard

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -360,6 +360,10 @@ input[data-correctness="incorrect"]:checked {
   animation: blink 2s step-start infinite;
 }
 
+.door-lock .keyboard {
+  --keyboard-key-height: 64px;
+}
+
 .door-lock #main-display,
 .door-lock #magie-staging {
   display: flex;

--- a/src/components/DoorLock.tsx
+++ b/src/components/DoorLock.tsx
@@ -110,7 +110,7 @@ const DoorLock = (props: DoorLockProps) => {
     }
     if (gameState === "idle" || gameState === "entering" || gameState === "rejected") {
       setCardBits(stagingBits);
-      const isCorrect = stagingBits.equals(winSequence);
+      const isCorrect = parseInt(stagingBits.toPlainString(), 2) === parseInt(winSequence.toPlainString(), 2);
       if (isCorrect) {
         setHint("You got it!");
         if (winAudio.current) {
@@ -183,35 +183,37 @@ const DoorLock = (props: DoorLockProps) => {
         }
       </div>
       <div id="puzzle-inputs">
-        <div className="decode-keyboard-row" role="group" aria-label="Bit input">
-          <button type="button" className="decode-keyboard-key" aria-label="1" onClick={() => appendBit("1")}>
-            <img src={keyboardAssetMap["keyboard_Bit_on_32x32.png"]}
-                 alt=""
-                 aria-hidden="true"
-                 draggable={false}
-                 className="decode-keyboard-key-image" />
-          </button>
-          <button type="button" className="decode-keyboard-key" aria-label="0" onClick={() => appendBit("0")}>
-            <img src={keyboardAssetMap["keyboard_Bit_off_32x32.png"]}
-                 alt=""
-                 aria-hidden="true"
-                 draggable={false}
-                 className="decode-keyboard-key-image" />
-          </button>
-          <button type="button" className="decode-keyboard-key" aria-label="delete" onClick={deleteBit}>
-            <img src={keyboardAssetMap["keyboard_delete_32x32.png"]}
-                 alt=""
-                 aria-hidden="true"
-                 draggable={false}
-                 className="decode-keyboard-key-image" />
-          </button>
-          <button type="button" className="decode-keyboard-key" aria-label="submit" onClick={submit}>
-            <img src={keyboardAssetMap["keyboard_return_32x32.png"]}
-                 alt=""
-                 aria-hidden="true"
-                 draggable={false}
-                 className="decode-keyboard-key-image" />
-          </button>
+        <div className="keyboard">
+          <div className="keyboard-row" role="group" aria-label="Bit input">
+            <button type="button" className="keyboard-key" aria-label="1" onClick={() => appendBit("1")}>
+              <img src={keyboardAssetMap["keyboard_Bit_on_32x32.png"]}
+                   alt=""
+                   aria-hidden="true"
+                   draggable={false}
+                   className="keyboard-key-image" />
+            </button>
+            <button type="button" className="keyboard-key" aria-label="0" onClick={() => appendBit("0")}>
+              <img src={keyboardAssetMap["keyboard_Bit_off_32x32.png"]}
+                   alt=""
+                   aria-hidden="true"
+                   draggable={false}
+                   className="keyboard-key-image" />
+            </button>
+            <button type="button" className="keyboard-key" aria-label="delete" onClick={deleteBit}>
+              <img src={keyboardAssetMap["keyboard_delete_32x32.png"]}
+                   alt=""
+                   aria-hidden="true"
+                   draggable={false}
+                   className="keyboard-key-image" />
+            </button>
+            <button type="button" className="keyboard-key" aria-label="submit" onClick={submit}>
+              <img src={keyboardAssetMap["keyboard_return_32x32.png"]}
+                   alt=""
+                   aria-hidden="true"
+                   draggable={false}
+                   className="keyboard-key-image" />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/OnScreenKeyboard.css
+++ b/src/components/OnScreenKeyboard.css
@@ -1,7 +1,4 @@
-.decode-keyboard {
-  --decode-key-height: clamp(23px, 7.6vw, 32px);
-  width: min(100%, 34rem);
-  margin: 0 auto;
+.keyboard {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
@@ -9,14 +6,14 @@
   touch-action: manipulation;
 }
 
-.decode-keyboard-row {
+.keyboard-row {
   display: flex;
   flex-wrap: nowrap;
   justify-content: center;
   gap: clamp(0.15rem, 0.9vw, 0.3rem);
 }
 
-.decode-keyboard-key {
+.keyboard-key {
   margin: 0;
   padding: 0;
   border: none;
@@ -28,32 +25,39 @@
   cursor: pointer;
 }
 
-.decode-keyboard-key:focus-visible {
+.keyboard-key:focus-visible {
   outline: 2px solid #dfed84;
   outline-offset: 2px;
   border-radius: 0.25rem;
 }
 
-.decode-keyboard-key:disabled {
+.keyboard-key:disabled {
   opacity: 0.65;
   cursor: default;
 }
 
-.decode-keyboard-key-image {
-  height: var(--decode-key-height);
+.keyboard-key-image {
+  height: var(--keyboard-key-height);
   width: auto;
   display: block;
   image-rendering: pixelated;
   transform: translateY(0);
 }
 
-.decode-keyboard-key:not(:disabled):active .decode-keyboard-key-image {
+.keyboard-key:not(:disabled):active .keyboard-key-image {
   transform: translateY(1px);
   filter: brightness(1.1);
 }
 
+/* Decode-specific sizing and width constraint */
+.decode-keyboard {
+  --keyboard-key-height: clamp(23px, 7.6vw, 32px);
+  width: min(100%, 34rem);
+  margin: 0 auto;
+}
+
 @media (max-width: 360px) {
   .decode-keyboard {
-    --decode-key-height: clamp(20px, 6.4vw, 26px);
+    --keyboard-key-height: clamp(20px, 6.4vw, 26px);
   }
 }

--- a/src/components/OnScreenKeyboard.tsx
+++ b/src/components/OnScreenKeyboard.tsx
@@ -120,14 +120,14 @@ const OnScreenKeyboard: FC<OnScreenKeyboardProps> = (
   }, [disabled, onCharacter, onDelete, onReturn]);
 
   return (
-    <div className="decode-keyboard" role="group" aria-label="On-screen keyboard">
+    <div className="keyboard decode-keyboard" role="group" aria-label="On-screen keyboard">
       {KEY_ROWS.map((keyRow, rowIndex) => (
-        <div className="decode-keyboard-row" key={`decode-keyboard-row-${rowIndex}`}>
+        <div className="keyboard-row" key={`keyboard-row-${rowIndex}`}>
           {keyRow.map((key) => (
             <button
               type="button"
               key={key.id}
-              className="decode-keyboard-key"
+              className="keyboard-key"
               onClick={() => handlePress(key)}
               disabled={disabled}
               aria-label={key.ariaLabel}
@@ -137,7 +137,7 @@ const OnScreenKeyboard: FC<OnScreenKeyboardProps> = (
                 alt=""
                 aria-hidden="true"
                 draggable={false}
-                className="decode-keyboard-key-image"
+                className="keyboard-key-image"
               />
             </button>
           ))}


### PR DESCRIPTION
Renames decode-keyboard* CSS classes to shared keyboard* classes so the structure is not falsely associated with the decode puzzle type. Decode- specific sizing and width live in a .decode-keyboard modifier; DoorLock (encode-type) gets its own --keyboard-key-height: 64px via .door-lock.

Also fixes win detection to compare numeric values instead of bit-exact sequences, consistent with the numeric difference hint already shown.