### PR TITLE
Simplify StoryPage font handling — remove auto-scaling and user adjustment

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -329,6 +329,7 @@ input[data-correctness="incorrect"]:checked {
   padding: 1rem;
   width: 44px;
   height: 44px;
+  text-transform: none;
 }
 
 .activate-dialog.left {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,10 +70,7 @@ function App() {
   const [showHowTo, setShowHowTo] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [useLcdFont, setUseLcdFont] = useState(() => (localStorage.getItem('useLcdFont') || 'true') === 'true');
-  const [storyFontAdjust, setStoryFontAdjust] = useState(() => parseInt(
-    localStorage.getItem('storyFontAdjust') || '0',
-    10));
-  const [headerScrollOffset, setHeaderScrollOffset] = useState(0);
+const [headerScrollOffset, setHeaderScrollOffset] = useState(0);
   const [isHeaderCollapsed, setIsHeaderCollapsed] = useState(false);
   const routeContentRef = useRef<HTMLDivElement | null>(null);
   const activeScrollContainer = useRef<HTMLElement | null>(null);
@@ -357,9 +354,7 @@ function App() {
         {showSettings && (
           <Dialog onClose={() => setShowSettings(false)}>
             <SettingsContent useLcdFont={useLcdFont}
-                             setUseLcdFont={setUseLcdFont}
-                             storyFontAdjust={storyFontAdjust}
-                             setStoryFontAdjust={setStoryFontAdjust} />
+                             setUseLcdFont={setUseLcdFont} />
           </Dialog>
         )}
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -323,7 +323,7 @@ function App() {
             source: 'activate_dialog',
             dialog: 'settings',
           });
-        }}>⋮
+        }}>Aa
         </button>
         <button type={"button"}
                 aria-label={"show how-to information"}

--- a/src/components/SettingsContent.tsx
+++ b/src/components/SettingsContent.tsx
@@ -4,11 +4,9 @@ import ReactGA4 from "react-ga4";
 interface SettingsContentProps {
   useLcdFont: boolean;
   setUseLcdFont: (value: boolean) => void;
-  storyFontAdjust: number;
-  setStoryFontAdjust: (value: number) => void;
 }
 
-export default function SettingsContent({ useLcdFont, setUseLcdFont, storyFontAdjust, setStoryFontAdjust }: SettingsContentProps) {
+export default function SettingsContent({ useLcdFont, setUseLcdFont }: SettingsContentProps) {
 
   const handleFontToggle = (e: ChangeEvent<HTMLInputElement>) => {
     const isShowLcdFontSelected = e.target.checked;
@@ -19,13 +17,6 @@ export default function SettingsContent({ useLcdFont, setUseLcdFont, storyFontAd
       action: 'toggle_font',
       value: isShowLcdFontSelected ? 'hd44780' : 'press_start_2p',
     });
-  };
-
-  const adjustStoryFont = (delta: number) => {
-    const next = storyFontAdjust + delta;
-    setStoryFontAdjust(next);
-    localStorage.setItem('storyFontAdjust', String(next));
-    window.dispatchEvent(new StorageEvent('storage', { key: 'storyFontAdjust', newValue: String(next) }));
   };
 
   return (
@@ -39,12 +30,6 @@ export default function SettingsContent({ useLcdFont, setUseLcdFont, storyFontAd
         />
         Use LCD font
       </label>
-      <div>
-        <span>Story font size</span>
-        <button type="button" onClick={() => adjustStoryFont(-1)}>-</button>
-        <span>{storyFontAdjust > 0 ? `+${storyFontAdjust}` : storyFontAdjust}</span>
-        <button type="button" onClick={() => adjustStoryFont(1)}>+</button>
-      </div>
     </>
   );
 }

--- a/src/components/StoryPage.tsx
+++ b/src/components/StoryPage.tsx
@@ -94,7 +94,7 @@ function paginateLines(lines: string[], rows: number): string[][] {
   return pages.length > 0 ? pages : [[]];
 }
 
-const DISPLAY_MIN_CHARS = 26;
+const CHAR_COUNT_RANGE = [24, 70] as const;
 
 export function StoryPage() {
   const { slug } = useParams();
@@ -107,21 +107,24 @@ export function StoryPage() {
   const [cols, setCols] = useState(40);
   const [rows, setRows] = useState(20);
   const [fontSize, setFontSize] = useState<number | null>(null);
-  const [fontSizeAdjust, setFontSizeAdjust] = useState<number>(
+  /**
+   * User font adjustment factor
+   */
+  const [userFontAdjustment, setUserFontAdjustment] = useState<number>(
     () => parseInt(localStorage.getItem('storyFontAdjust') || '0', 10)
   );
-  const fontSizeAdjustRef = useRef(fontSizeAdjust);
+  const userFontAdjustRef = useRef(userFontAdjustment);
 
   useEffect(() => {
     const handler = (e: StorageEvent) => {
       if (e.key === 'storyFontAdjust') {
-        setFontSizeAdjust(parseInt(e.newValue || '0', 10));
+        setUserFontAdjustment(parseInt(e.newValue || '0', 10));
       }
     };
     window.addEventListener('storage', handler);
     return () => window.removeEventListener('storage', handler);
   }, []);
-  useEffect(() => { fontSizeAdjustRef.current = fontSizeAdjust; }, [fontSizeAdjust]);
+  useEffect(() => { userFontAdjustRef.current = userFontAdjustment; }, [userFontAdjustment]);
   const containerRef = useRef<HTMLDivElement>(null);
   const rulerRef = useRef<HTMLSpanElement>(null);
 
@@ -131,21 +134,34 @@ export function StoryPage() {
     if (!ruler || !container) {
       return;
     }
-    const charWidth = ruler.offsetWidth;
+
+    const currentFontCharWidth = ruler.offsetWidth;
     const lineHeight = ruler.offsetHeight;
-    if (!charWidth || !lineHeight) {
+    if (!currentFontCharWidth || !lineHeight) {
       return;
     }
+
+    // sizes in pixels
     const containerWidth = container.clientWidth;
     const containerHeight = container.clientHeight;
     const currentFontSize = parseFloat(getComputedStyle(container).fontSize);
-    const scale = containerWidth / (DISPLAY_MIN_CHARS * charWidth);
-    const baseFontSize = currentFontSize * scale;
-    const newFontSize = baseFontSize + fontSizeAdjustRef.current;
-    const ratio = newFontSize / currentFontSize;
-    setFontSize(prev => (prev !== null && Math.abs(prev - newFontSize) < 1 ? prev : newFontSize));
-    setCols(Math.floor(containerWidth / (charWidth * ratio)));
-    setRows(Math.floor(containerHeight / (lineHeight * ratio)));
+    const measuredColCount = containerWidth / currentFontCharWidth;
+    // if the current (pre-adjusted) font size allows for more than 70 character columns, clamp it down to 70 (top of the range, see above)
+    const clampedMaxCols = Math.min(CHAR_COUNT_RANGE[1], measuredColCount);
+    // just check in case `clampedMaxCols` is way small (like, if measuredColCount is < 12 because the window is super narrow)
+    const clampedCols = Math.max(CHAR_COUNT_RANGE[0], clampedMaxCols);
+    // calculate the current, measured, expected, "natural" column count.
+    const colCountScaleFactor = measuredColCount / clampedCols; // e.g. measuredColCount: 8 / clampedCols: 12 => colCountScaleFactor = 8/12 => 0.67 (#SixSeven)
+    // scale the font size by the calculated column scale
+    const scaledFontSize = currentFontSize * colCountScaleFactor;
+    const adjustedFontSize = scaledFontSize + userFontAdjustRef.current;
+    const calculatedFontSizeRatio = adjustedFontSize / currentFontSize;
+    setFontSize(prev => (prev !== null && Math.abs(prev - adjustedFontSize) < 1 ? prev : adjustedFontSize));
+    setCols(Math.floor(containerWidth / (currentFontCharWidth * calculatedFontSizeRatio)));
+    setRows(Math.floor(containerHeight / (lineHeight * calculatedFontSizeRatio))); // is this correct?
+    // what should I set a watch for in the browser dev tools?
+    // I think I installed "react dev tools", can I just watch the fontSize state variable?
+
   }, []);
 
   useLayoutEffect(() => {
@@ -167,7 +183,7 @@ export function StoryPage() {
 
   useLayoutEffect(() => {
     measure();
-  }, [fontSizeAdjust, measure]);
+  }, [userFontAdjustment, measure]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/src/components/StoryPage.tsx
+++ b/src/components/StoryPage.tsx
@@ -4,22 +4,23 @@ import { stories } from "../stories.ts";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 function importStory(fileName: string) {
-  return import.meta.glob("../assets/story/*.md", { query: "?raw", import: "default", eager: true })[
-    `../assets/story/${fileName}`
-    ] as string;
+  return import.meta.glob(
+          "../assets/story/*.md",
+          { query: "?raw", import: "default", eager: true }
+  )[`../assets/story/${fileName}`] as string;
 }
 
 function stripMarkdown(text: string): string {
   return text
-    .replace(/^#{1,6}\s+/, '')
-    .replace(/\*\*(.+?)\*\*/gs, '$1')
-    .replace(/\*(.+?)\*/gs, '$1')
-    .replace(/__(.+?)__/gs, '$1')
-    .replace(/_(.+?)_/gs, '$1')
-    .replace(/`(.+?)`/gs, '$1')
-    .replace(/\[(.+?)\]\(.+?\)/gs, '$1')
-    .replace(/^[-*_]{3,}$/, '')
-    .trim();
+  .replace(/^#{1,6}\s+/, '')
+  .replace(/\*\*(.+?)\*\*/gs, '$1')
+  .replace(/\*(.+?)\*/gs, '$1')
+  .replace(/__(.+?)__/gs, '$1')
+  .replace(/_(.+?)_/gs, '$1')
+  .replace(/`(.+?)`/gs, '$1')
+  .replace(/\[(.+?)\]\(.+?\)/gs, '$1')
+  .replace(/^[-*_]{3,}$/, '')
+  .trim();
 }
 
 function wordWrap(text: string, cols: number): string[] {
@@ -94,8 +95,6 @@ function paginateLines(lines: string[], rows: number): string[][] {
   return pages.length > 0 ? pages : [[]];
 }
 
-const CHAR_COUNT_RANGE = [24, 70] as const;
-
 export function StoryPage() {
   const { slug } = useParams();
 
@@ -106,62 +105,18 @@ export function StoryPage() {
   const [pageIndex, setPageIndex] = useState(0);
   const [cols, setCols] = useState(40);
   const [rows, setRows] = useState(20);
-  const [fontSize, setFontSize] = useState<number | null>(null);
-  /**
-   * User font adjustment factor
-   */
-  const [userFontAdjustment, setUserFontAdjustment] = useState<number>(
-    () => parseInt(localStorage.getItem('storyFontAdjust') || '0', 10)
-  );
-  const userFontAdjustRef = useRef(userFontAdjustment);
-
-  useEffect(() => {
-    const handler = (e: StorageEvent) => {
-      if (e.key === 'storyFontAdjust') {
-        setUserFontAdjustment(parseInt(e.newValue || '0', 10));
-      }
-    };
-    window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
-  }, []);
-  useEffect(() => { userFontAdjustRef.current = userFontAdjustment; }, [userFontAdjustment]);
   const containerRef = useRef<HTMLDivElement>(null);
   const rulerRef = useRef<HTMLSpanElement>(null);
 
   const measure = useCallback(() => {
     const ruler = rulerRef.current;
     const container = containerRef.current;
-    if (!ruler || !container) {
-      return;
-    }
-
-    const currentFontCharWidth = ruler.offsetWidth;
+    if (!ruler || !container) { return; }
+    const charWidth = ruler.offsetWidth;
     const lineHeight = ruler.offsetHeight;
-    if (!currentFontCharWidth || !lineHeight) {
-      return;
-    }
-
-    // sizes in pixels
-    const containerWidth = container.clientWidth;
-    const containerHeight = container.clientHeight;
-    const currentFontSize = parseFloat(getComputedStyle(container).fontSize);
-    const measuredColCount = containerWidth / currentFontCharWidth;
-    // if the current (pre-adjusted) font size allows for more than 70 character columns, clamp it down to 70 (top of the range, see above)
-    const clampedMaxCols = Math.min(CHAR_COUNT_RANGE[1], measuredColCount);
-    // just check in case `clampedMaxCols` is way small (like, if measuredColCount is < 12 because the window is super narrow)
-    const clampedCols = Math.max(CHAR_COUNT_RANGE[0], clampedMaxCols);
-    // calculate the current, measured, expected, "natural" column count.
-    const colCountScaleFactor = measuredColCount / clampedCols; // e.g. measuredColCount: 8 / clampedCols: 12 => colCountScaleFactor = 8/12 => 0.67 (#SixSeven)
-    // scale the font size by the calculated column scale
-    const scaledFontSize = currentFontSize * colCountScaleFactor;
-    const adjustedFontSize = scaledFontSize + userFontAdjustRef.current;
-    const calculatedFontSizeRatio = adjustedFontSize / currentFontSize;
-    setFontSize(prev => (prev !== null && Math.abs(prev - adjustedFontSize) < 1 ? prev : adjustedFontSize));
-    setCols(Math.floor(containerWidth / (currentFontCharWidth * calculatedFontSizeRatio)));
-    setRows(Math.floor(containerHeight / (lineHeight * calculatedFontSizeRatio))); // is this correct?
-    // what should I set a watch for in the browser dev tools?
-    // I think I installed "react dev tools", can I just watch the fontSize state variable?
-
+    if (!charWidth || !lineHeight) { return; }
+    setCols(Math.floor(container.clientWidth / charWidth));
+    setRows(Math.floor(container.clientHeight / lineHeight));
   }, []);
 
   useLayoutEffect(() => {
@@ -181,18 +136,14 @@ export function StoryPage() {
     };
   }, [measure]);
 
-  useLayoutEffect(() => {
-    measure();
-  }, [userFontAdjustment, measure]);
-
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPageIndex(0);
   }, [storyMarkdown, cols, rows]);
 
   const pages = useMemo(
-    () => storyMarkdown ? paginateLines(buildLines(storyMarkdown, cols), rows) : [[]],
-    [storyMarkdown, cols, rows]
+          () => storyMarkdown ? paginateLines(buildLines(storyMarkdown, cols), rows) : [[]],
+          [storyMarkdown, cols, rows]
   );
 
   useEffect(() => {
@@ -224,43 +175,43 @@ export function StoryPage() {
   const canGoForward = pageIndex < pages.length - 1;
 
   return (
-    <div className="story-page" style={fontSize != null ? { fontSize: `${fontSize}px` } : undefined}>
-      <div
-        ref={containerRef}
-        id="main-display"
-        className="paginated"
-        onClick={() => {
-          if (canGoForward) {
-            setPageIndex(p => p + 1);
-          }
-        }}
-      >
-        <span ref={rulerRef} className="char-ruler">M</span>
-        <div className="story-lines">
-          {currentPage.map((line, i) => (
-            <div key={i} className="story-line">{line || ' '}</div>
-          ))}
-        </div>
-      </div>
-      <div className="story-cta" style={pageIndex !== pages.length - 1 ? { visibility: 'hidden' } : undefined}>
-        <Link to="/">Play the game!</Link>
-      </div>
-      <nav className="story-navigation">
-        <div className="left-item">
-          {prev ? <Link to={`/story/${prev.slug}`}>|◀◀{prev.slug}</Link> : <span />}
-        </div>
-        <div className="center">
-          <div className="page-controls">
-            <button type="button" onClick={() => setPageIndex(p => p - 1)} disabled={!canGoBack}>▲</button>
-            <span>{pageIndex + 1}/{pages.length}</span>
-            <button type="button" onClick={() => setPageIndex(p => p + 1)} disabled={!canGoForward}>▼</button>
+          <div className="story-page">
+            <div
+                    ref={containerRef}
+                    id="main-display"
+                    className="paginated"
+                    onClick={() => {
+                      if (canGoForward) {
+                        setPageIndex(p => p + 1);
+                      }
+                    }}
+            >
+              <span ref={rulerRef} className="char-ruler">M</span>
+              <div className="story-lines">
+                {currentPage.map((line, i) => (
+                        <div key={i} className="story-line">{line || ' '}</div>
+                ))}
+              </div>
+            </div>
+            <div className="story-cta" style={pageIndex !== pages.length - 1 ? { visibility: 'hidden' } : undefined}>
+              <Link to="/">Play the game!</Link>
+            </div>
+            <nav className="story-navigation">
+              <div className="left-item">
+                {prev ? <Link to={`/story/${prev.slug}`}>|◀◀{prev.slug}</Link> : <span />}
+              </div>
+              <div className="center">
+                <div className="page-controls">
+                  <button type="button" onClick={() => setPageIndex(p => p - 1)} disabled={!canGoBack}>▲</button>
+                  <span>{pageIndex + 1}/{pages.length}</span>
+                  <button type="button" onClick={() => setPageIndex(p => p + 1)} disabled={!canGoForward}>▼</button>
+                </div>
+                <Link to="/story">&#x23CF; Story Index</Link>
+              </div>
+              <div className="right-item">
+                {next ? <Link to={`/story/${next.slug}`}>{next.slug}▶▶|</Link> : <span />}
+              </div>
+            </nav>
           </div>
-          <Link to="/story">&#x23CF; Story Index</Link>
-        </div>
-        <div className="right-item">
-          {next ? <Link to={`/story/${next.slug}`}>{next.slug}▶▶|</Link> : <span />}
-        </div>
-      </nav>
-    </div>
   );
 }


### PR DESCRIPTION
The story reader previously auto-scaled font size to fit a target character count per line, and exposed +/- buttons in the Settings dialog to let users fine-tune it. Both features are removed in favour of the browser's built-in text size controls (Cmd+/Cmd– on desktop, the "aA" button in Safari iOS), which already work correctly across the whole site.

**Changes:**
- Remove `CHAR_COUNT_RANGE` / `DISPLAY_MIN_CHARS` scaling logic from `StoryPage` — `measure()` now simply reads `cols` and `rows` from the actual rendered font size, with no manipulation
- Remove `fontSize` state, `userFontAdjustment` state + ref, and all related effects from `StoryPage`
- Remove "Story font size" +/- control from `SettingsContent` and its `storyFontAdjust` prop
- Remove `storyFontAdjust` state from `App`
- Change the settings button label from `⋮` to `Aa` (with `text-transform: none` on `.activate-dialog` so it renders mixed-case)

**Why:** The auto-scaling introduced a feedback loop bug — on page load with a non-zero saved adjustment, `measure()` would re-apply the offset on every ResizeObserver callback, shrinking the font to a few pixels. Removing the feature entirely is cleaner than fixing it, since browser controls already solve the problem for all users without any custom UI.